### PR TITLE
Update `tailwindcss-font-inter` and remove deprecated option

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,7 +45,6 @@ module.exports = {
   plugins: [
     require("tailwindcss-font-inter")({
       importFontFace: true,
-      disableUnusedFeatures: true,
     }),
     require("tailwindcss-animatecss")({
       classes: ["animated", "fadeIn", "fadeInUp"],


### PR DESCRIPTION
The `disableUnusedFeatures` flag is [not necessary as of Tailwind 2](https://github.com/semencov/tailwindcss-font-inter/blob/88a90a79de81618d318fb88a60e4bd665397d55a/CHANGELOG.md#version-200).