### PR TITLE
Add href to “Get started” anchor

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -68,6 +68,7 @@
       >
         <a
           class="w-full mb-4 whitespace-no-wrap bg-indigo-600 btn btn-tall md:w-auto hover:bg-indigo-500 sm:mr-2"
+          href="#"
         >
           Get started
         </a>


### PR DESCRIPTION
this pr fix very tiny issue. it just add href attribute to get started <a> to be clickable "have cursor pointer"